### PR TITLE
Use class_name method for result class name

### DIFF
--- a/lib/minitest/binstub_reporter.rb
+++ b/lib/minitest/binstub_reporter.rb
@@ -4,7 +4,7 @@ module Minitest
   class BinstubReporter < SprintReporter
     def print_list
       results.each do |result|
-        puts "  minitest -n #{result.class}##{result.name}"
+        puts "  minitest -n #{result.class_name}##{result.name}"
       end
     end
   end

--- a/lib/minitest/rake_reporter.rb
+++ b/lib/minitest/rake_reporter.rb
@@ -4,7 +4,7 @@ module Minitest
   class RakeReporter < SprintReporter
     def print_list
       results.each do |result|
-        puts "  rake N=#{result.class}##{result.name}"
+        puts "  rake N=#{result.class_name}##{result.name}"
       end
     end
   end


### PR DESCRIPTION
The `class` method returns `Minitest::Result` and not the original parent
class the tests were defined in.

This fixes the failed sprint list for `--binstub` and `--rake` options.