### PR TITLE
Allow rake task name to be passed as an argument and repeated back in failure list

### DIFF
--- a/lib/minitest/rake_reporter.rb
+++ b/lib/minitest/rake_reporter.rb
@@ -4,7 +4,7 @@ module Minitest
   class RakeReporter < SprintReporter
     def print_list
       results.each do |result|
-        puts "  rake N=#{result.class_name}##{result.name}"
+        puts ["  rake", options[:rake_task], "N=#{result.class_name}##{result.name}"].compact.join(" ")
       end
     end
   end

--- a/lib/minitest/sprint_plugin.rb
+++ b/lib/minitest/sprint_plugin.rb
@@ -2,8 +2,9 @@ require "minitest"
 
 module Minitest
   def self.plugin_sprint_options opts, options # :nodoc:
-    opts.on "--rake", "Report how to re-run failures with rake." do
+    opts.on "--rake [TASK]", "Report how to re-run failures with rake." do |task|
       options[:sprint] = :rake
+      options[:rake_task] = task
     end
 
     opts.on "--binstub", "Report how to re-run failures with minitest." do

--- a/lib/minitest/sprint_plugin.rb
+++ b/lib/minitest/sprint_plugin.rb
@@ -16,10 +16,10 @@ module Minitest
     case options[:sprint]
     when :rake then
       require "minitest/rake_reporter"
-      self.reporter << Minitest::RakeReporter.new
+      self.reporter << Minitest::RakeReporter.new(options)
     when :binstub then
       require "minitest/binstub_reporter"
-      self.reporter << Minitest::BinstubReporter.new
+      self.reporter << Minitest::BinstubReporter.new(options)
     end
   end
 end

--- a/lib/minitest/sprint_reporter.rb
+++ b/lib/minitest/sprint_reporter.rb
@@ -1,8 +1,10 @@
 module Minitest
   class SprintReporter < AbstractReporter
     attr_accessor :results
+    attr_accessor :options
 
-    def initialize
+    def initialize(options)
+      self.options = options
       self.results = []
     end
 


### PR DESCRIPTION
This will allow the failure to be run using the same test task as the original failure.

```
$ BAD=true rake test A="--rake foo"
Run options: --rake foo --seed 30155

# Running:

.ESF

Finished in 0.000332s, 12048.1929 runs/s, 6024.0965 assertions/s.

  1) Error:
TestMinitestSprint#test_error:
RuntimeError: nope
    test/test_minitest_sprint.rb:19:in `test_error'

  2) Failure:
TestMinitestSprint#test_fail [test/test_minitest_sprint.rb:15]:
write tests or I will kneecap you

4 runs, 2 assertions, 1 failures, 1 errors, 1 skips

You have skipped tests. Run with --verbose for details.

Happy Happy Sprint List:

  rake foo N=TestMinitestSprint#test_error
  rake foo N=TestMinitestSprint#test_fail

rake aborted!
Command failed with status (1): [/Users/adam/.local/share/mise/installs/ruby/3.3.3/bin/ruby -I:lib:test:. -w -e 'require "minitest/autorun"; require "test/test_minitest_sprint.rb"' -- --rake foo]

Tasks: TOP => test
(See full trace by running task with --trace)
```