### PR TITLE
Document usage with Minitest TestTask and extra_args

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -45,6 +45,11 @@ method names. When running tests, just hit tab after -n. For example:
   test_thingy_failing_filtered
   ... etc ...
 
+  # Rakefile
+  Minitest::TestTask.create do |t|
+    t.extra_args = ["--rake"] # Or --binstub
+  end
+
 == REQUIREMENTS:
 
 * ruby


### PR DESCRIPTION
It's not super clear that the reporter can be set via `extra_args` (at least it wasn't for me, for many years).